### PR TITLE
fixing the zeroconf registration

### DIFF
--- a/internal/pkg/checks/preflight.go
+++ b/internal/pkg/checks/preflight.go
@@ -81,7 +81,12 @@ func PreflightConfiguration(config cfgh.Config) {
 	}
 	convert.SetTimeout(config.Timeout)
 	setMathRenderingEngine(config)
-	go zero.Register(config)
+	go func() {
+		_, err := zero.Register(config)
+		if err != nil {
+			log.Errorf("Error registering zero plugin: %s", err)
+		}
+	}()
 }
 
 func PreflightConfigCheck(config cfgh.Config) {

--- a/internal/pkg/zero/register.go
+++ b/internal/pkg/zero/register.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Register(cfg cfgh.Config) {
+func Register(cfg cfgh.Config) (*zeroconf.Server, error) {
 	var add []string
 	add = strings.Split(cfg.ListenOnIP, ":")
 	if len(add) < 2 {
@@ -17,10 +17,12 @@ func Register(cfg cfgh.Config) {
 	}
 	port, err := strconv.Atoi(add[1])
 	if err != nil {
-		log.Fatalf("Invalid port in ListenOnIP: %v", err)
+		log.Errorf("Invalid port in ListenOnIP: %v", err)
+		return nil, err
 	}
-	_, err = zeroconf.Register("pandoc", "_http._tcp", add[0], port, nil, nil)
+	server, err := zeroconf.Register("pandoc", "_http._tcp", add[0], port, nil, nil)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
+	return server, nil
 }


### PR DESCRIPTION
This pull request refactors the plugin registration process to improve error handling and reporting. The changes ensure that errors during the registration of the zero plugin are logged rather than causing the application to exit, making the system more robust and easier to debug.

**Error handling improvements:**

* The `Register` function in `internal/pkg/zero/register.go` now returns an error instead of terminating the process on failure, allowing for more graceful error handling.
* In `internal/pkg/checks/preflight.go`, the plugin registration is wrapped in a goroutine that logs any errors encountered during registration, preventing silent failures and application crashes.