### PR TITLE
solved https://github.com/dozro/simple-pandoc-server/issues/9

### DIFF
--- a/internal/pkg/checks/preflight.go
+++ b/internal/pkg/checks/preflight.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func searchPackageAndSetEnv(pkgname string, envname string) {
+func searchPackageAndSetEnv(pkgname string, envname string, wg *sync.WaitGroup) {
 	path, err := exec.LookPath(pkgname)
 	if err != nil {
 		log.Errorf("Could not find package %s in path not setting it as Env %s, it has to manually be set or cmdline args have to be used: %s", pkgname, envname, err)
@@ -20,6 +20,7 @@ func searchPackageAndSetEnv(pkgname string, envname string) {
 	}
 	log.Infof("found package %s in path setting it as Env %s: %s", pkgname, envname, path)
 	_ = os.Setenv(envname, path)
+	wg.Done()
 }
 
 func determineVersionOfPackageAndSetEnv(command string, envName string) {
@@ -44,9 +45,9 @@ func PreflightPackageSearch() {
 	log.Info("searching for packages")
 	var searchPackageAndSetEnvGroup sync.WaitGroup
 	searchPackageAndSetEnvGroup.Add(3)
-	go searchPackageAndSetEnv("pandoc", "PANDOC_COMMAND")
-	go searchPackageAndSetEnv("pdflatex", "LATEX_COMMAND")
-	go searchPackageAndSetEnv("typst", "TYPST_COMMAND")
+	go searchPackageAndSetEnv("pandoc", "PANDOC_COMMAND", &searchPackageAndSetEnvGroup)
+	go searchPackageAndSetEnv("pdflatex", "LATEX_COMMAND", &searchPackageAndSetEnvGroup)
+	go searchPackageAndSetEnv("typst", "TYPST_COMMAND", &searchPackageAndSetEnvGroup)
 	searchPackageAndSetEnvGroup.Wait()
 }
 


### PR DESCRIPTION
see issue: https://github.com/dozro/simple-pandoc-server/issues/9

This pull request updates the package search logic in the preflight checks to use a `sync.WaitGroup` for improved goroutine management and synchronization. This change ensures that all package searches complete before proceeding, which can help prevent race conditions and improve reliability.

Concurrency improvements:

* Replaced individual goroutine launches for package searches with a `sync.WaitGroup` in `PreflightPackageSearch`, ensuring all searches (`pandoc`, `pdflatex`, `typst`) are properly synchronized and completed before continuing.
* Added the `sync` package import to support the new concurrency control.