### PR TITLE
updated github workflow in docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,12 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Extract version number
         id: vars
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=" >> $GITHUB_OUTPUT
+          fi
 
 
       # Install the cosign tool except on PR


### PR DESCRIPTION
This pull request updates the Docker publishing workflow in `.github/workflows/docker-publish.yml` to automate tagging and pushing images to Docker Hub. The workflow now logs in to Docker Hub, extracts the version from the tag, and tags/pushes images with both `latest` and version-specific tags.

**Docker Hub integration and image publishing:**

* Added a step to log in to Docker Hub using credentials from repository secrets, enabling authenticated image pushes.
* Implemented extraction of the version number from the GitHub tag reference, making it available for use in image tagging.
* Added steps to tag the built Docker image as both `latest` and with the extracted version, and push both tags to Docker Hub, skipping this process for pull requests.