### PR TITLE
docker multiarch building in GitHub Workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request updates the Docker publishing workflow to improve support for building and publishing multi-platform images. The most important changes are the addition of QEMU setup and explicit targeting of both AMD64 and ARM64 platforms.

Multi-platform build support:

* Added a step to set up QEMU using `docker/setup-qemu-action@v3`, which enables emulation for building images for multiple architectures.
* Updated the Docker build step to specify `platforms: linux/amd64, linux/arm64`, ensuring images are built and published for both AMD64 and ARM64 architectures.