### PR TITLE
chore: disable Docker Hub tag and push steps

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,19 +92,19 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+#          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Tag and Push to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:latest
-          docker push ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:latest
-          docker tag ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:latest ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:${{ steps.vars.outputs.VERSION }}
-          docker push ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:${{ steps.vars.outputs.VERSION }}
+#      - name: Tag and Push to Docker Hub
+#        if: ${{ github.event_name != 'pull_request' }}
+#        run: |
+#          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:latest
+#          docker push ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:latest
+#          docker tag ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:latest ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:${{ steps.vars.outputs.VERSION }}
+#          docker push ${{ secrets.DOCKER_HUB_USER }}/simple-pandoc-server:${{ steps.vars.outputs.VERSION }}
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish


### PR DESCRIPTION
Comment out Docker Hub tagging and pushing steps.

This pull request makes minor adjustments to the Docker publishing workflow in `.github/workflows/docker-publish.yml`. The main change is that two steps related to multi-platform builds and Docker Hub tagging/pushing have been commented out, which means they will not be executed during workflow runs.

* Docker workflow steps for multi-platform builds (`platforms: linux/amd64,linux/arm64`) and tagging/pushing images to Docker Hub have been commented out, disabling these actions in the workflow.