### PR TITLE
fix: added missing done for go routine wait group

### DIFF
--- a/internal/pkg/checks/preflight.go
+++ b/internal/pkg/checks/preflight.go
@@ -16,6 +16,7 @@ func searchPackageAndSetEnv(pkgname string, envname string, wg *sync.WaitGroup) 
 	path, err := exec.LookPath(pkgname)
 	if err != nil {
 		log.Errorf("Could not find package %s in path not setting it as Env %s, it has to manually be set or cmdline args have to be used: %s", pkgname, envname, err)
+		wg.Done()
 		return
 	}
 	log.Infof("found package %s in path setting it as Env %s: %s", pkgname, envname, path)
@@ -44,7 +45,7 @@ func determineVersionOfPackageAndSetEnv(command string, envName string) {
 func PreflightPackageSearch() {
 	log.Info("searching for packages")
 	var searchPackageAndSetEnvGroup sync.WaitGroup
-	searchPackageAndSetEnvGroup.Add(2)
+	searchPackageAndSetEnvGroup.Add(3)
 	go searchPackageAndSetEnv("pandoc", "PANDOC_COMMAND", &searchPackageAndSetEnvGroup)
 	go searchPackageAndSetEnv("pdflatex", "LATEX_COMMAND", &searchPackageAndSetEnvGroup)
 	go searchPackageAndSetEnv("typst", "TYPST_COMMAND", &searchPackageAndSetEnvGroup)


### PR DESCRIPTION
see: https://github.com/dozro/simple-pandoc-server/issues/15

This pull request updates the package search logic in the `preflight.go` file to improve reliability and add support for an additional package. The main changes include ensuring proper synchronization when searching for packages and expanding the set of packages checked during preflight.

Synchronization improvements:
* Ensured that the wait group is properly decremented in `searchPackageAndSetEnv` when a package is not found, preventing potential deadlocks in concurrent execution.

Package search enhancements:
* Updated `PreflightPackageSearch` to search for three packages (`pandoc`, `pdflatex`, and `typst`) instead of two, and adjusted the wait group count accordingly.