### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-lint-test-vet.yml
+++ b/.github/workflows/go-lint-test-vet.yml
@@ -1,4 +1,6 @@
 name: go-lint-test-vet.yml
+permissions:
+  contents: read
 on:
   push:
     branches: [ '*' ]


### PR DESCRIPTION
Potential fix for [https://github.com/dozro/simple-pandoc-server/security/code-scanning/1](https://github.com/dozro/simple-pandoc-server/security/code-scanning/1)

To fix the problem, add a `permissions` block to the top level of the workflow file (`.github/workflows/go-lint-test-vet.yml`). This block should minimally grant only the permissions required for the workflow. In this case, since the workflow only reads the repository code and does not create, edit, or push anything (no releases, no uploads, no PR or issue modifications), the minimal permission of `contents: read` is sufficient. 

Generally, place the `permissions:` key after the `name:` and before the `on:` block at the top of the workflow file. No existing functionality will change, and no imports or further definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
